### PR TITLE
Rules Manager refact

### DIFF
--- a/src/LogicEngine/Extensions/Extensions.cs
+++ b/src/LogicEngine/Extensions/Extensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using LogicEngine.Interfaces;
+﻿using LogicEngine.Interfaces;
 using TinyFp;
 
 namespace LogicEngine.Extensions;
@@ -9,6 +8,6 @@ public static class Extensions
     public static bool SatisfiesRules<T>(this T @this, IRulesManager<T> manager) where T : new() =>
         manager.ItemSatisfiesRules(@this);
 
-    public static Either<IEnumerable<string>, Unit> SatisfiesRulesWithMessage<T>(this T @this, IRulesManager<T> manager) where T : new() =>
+    public static Either<string[], Unit> SatisfiesRulesWithMessage<T>(this T @this, IRulesManager<T> manager) where T : new() =>
         manager.ItemSatisfiesRulesWithMessage(@this);
 }

--- a/src/LogicEngine/Interfaces/IRulesManager.cs
+++ b/src/LogicEngine/Interfaces/IRulesManager.cs
@@ -7,7 +7,7 @@ namespace LogicEngine.Interfaces;
 public interface IRulesManager<T> where T : new()
 {
     RulesCatalog Catalog { set; }
-    Either<IEnumerable<string>, Unit> ItemSatisfiesRulesWithMessage(T item);
+    Either<string[], Unit> ItemSatisfiesRulesWithMessage(T item);
     bool ItemSatisfiesRules(T item);
     IEnumerable<T> Filter(IEnumerable<T> items);
     T FirstOrDefault(IEnumerable<T> items);

--- a/src/LogicEngine/RulesManager.cs
+++ b/src/LogicEngine/RulesManager.cs
@@ -23,10 +23,11 @@ public class RulesManager<T> : IRulesManager<T> where T : new()
     public RulesCatalog Catalog
     {
         set => (_itemSatisfiesRulesWithMessage, _itemSatisfiesRules) =
-                    _catalogCompiler
-                        .CompileCatalog<T>(value)
-                        .ToOption(_ => !_.Executables.Any())
-                        .Match(_ => (ItemSatisfiesRulesWithMessageUsingCatalog(_.Executables), ItemSatisfiesRulesUsingCatalog(_.Executables)),
+                    value
+                        .Map(_catalogCompiler.CompileCatalog<T>)
+                        .ToOption(_ => _.Executables,
+                                  _ => _.Executables.Length == 0)
+                        .Match(_ => (ItemSatisfiesRulesWithMessageUsingCatalog(_), ItemSatisfiesRulesUsingCatalog(_)),
                                () => (ItemSatisfiesRulesWithMessageAlwaysUnit, ItemSatisfiesRulesAlwaysTrue));
     }
 
@@ -44,16 +45,17 @@ public class RulesManager<T> : IRulesManager<T> where T : new()
 
     private static Func<T, Either<string[], Unit>> ItemSatisfiesRulesWithMessageUsingCatalog(Func<T, Either<string, Unit>>[][] rulesCatalog) =>
         item => Loop(rulesCatalog, item, Empty<string>())
-                    .Match(_ => Either<string[], Unit>.Left(_.Where(__ => __ != string.Empty).Distinct().ToArray()),
+                    .Match(Either<string[], Unit>.Left, 
                            () => Unit.Default);
 
     private static Option<string[]> Loop(Func<T, Either<string, Unit>>[][] rulesCatalog, T item, string[] errorCodes) =>
         rulesCatalog
             .ToOption(_ => _.First(),
-                      _ => !_.Any())
+                      _ => _.Length == 0)
             .Match(_ => EvaluateRuleSet(_, item)
-                            .Bind(__ => Loop(rulesCatalog.Skip(1).ToArray(), item, __.Concat(errorCodes).ToArray())),
-                   () => errorCodes.ToOption(_ => _.Length == 0));
+                            .Map(__ => __.Concat(errorCodes).ToArray())
+                            .Bind(__ => Loop(rulesCatalog.Skip(1).ToArray(), item, __)),
+                   () => CloseLoop(errorCodes));
 
     private static Option<string[]> EvaluateRuleSet(Func<T, Either<string, Unit>>[] ruleset, T item) =>
         ruleset
@@ -62,6 +64,11 @@ public class RulesManager<T> : IRulesManager<T> where T : new()
           .Select(_ => _.UnwrapLeft())
           .ToArray()
           .ToOption(_ => _.Length == 0);
+
+    private static Option<string[]> CloseLoop(string[] errorCodes) =>
+        errorCodes
+            .ToOption(_ => _.Where(__ => __ != string.Empty).Distinct().ToArray(),
+                      _ => _.Length == 0);
 
     /// <summary>
     ///     the full rules catalog is satisfied if at least one ruleSet is satisfied (OR)

--- a/src/LogicEngine/RulesManager.cs
+++ b/src/LogicEngine/RulesManager.cs
@@ -23,19 +23,16 @@ public class RulesManager<T> : IRulesManager<T> where T : new()
     public RulesCatalog Catalog
     {
         set => (_itemSatisfiesRulesWithMessage, _itemSatisfiesRules) =
-                    value
-                        .ToOption(_ => _.RulesSets == null || 
-                                       !_.RulesSets.Any())
-                        .Bind(_ => _catalogCompiler
-                                        .CompileCatalog<T>(_)
-                                        .ToOption(__ => !__.Executables.Any()))
+                    _catalogCompiler
+                        .CompileCatalog<T>(value)
+                        .ToOption(_ => !_.Executables.Any())
                         .Match(_ => (ItemSatisfiesRulesWithMessageUsingCatalog(_.Executables), ItemSatisfiesRulesUsingCatalog(_.Executables)),
                                () => (ItemSatisfiesRulesWithMessageAlwaysUnit, ItemSatisfiesRulesAlwaysTrue));
     }
 
     /// <summary>
     ///     the full rules catalog is satisfied if at least one ruleSet is satisfied (OR);
-    ///     a single ruleSet is satisfied iff ALL its rules are satisfied (AND)
+    ///     a single ruleSet is satisfied if ALL its rules are satisfied (AND)
     /// </summary>
     /// <param name="item"></param>
     /// <returns>RulesCatalogApplicationResult</returns>
@@ -66,7 +63,7 @@ public class RulesManager<T> : IRulesManager<T> where T : new()
 
     /// <summary>
     ///     the full rules catalog is satisfied if at least one ruleSet is satisfied (OR)
-    ///     a single ruleSet is satisfied iff ALL its rules are satisfied (AND)
+    ///     a single ruleSet is satisfied if ALL its rules are satisfied (AND)
     /// </summary>
     /// <param name="item"></param>
     /// <returns>bool</returns>

--- a/tests/LogicEngine.Unit.Tests/Extensions/ExtensionsTests.cs
+++ b/tests/LogicEngine.Unit.Tests/Extensions/ExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using FluentAssertions;
+﻿using FluentAssertions;
 using LogicEngine.Extensions;
 using LogicEngine.Interfaces;
 using Moq;
@@ -38,7 +37,7 @@ public class ExtensionsTests
     {
         var expected = satisfy
             ? TinyFp.Unit.Default
-            : Either<IEnumerable<string>, TinyFp.Unit>.Left(new[] { "a", "b" });
+            : Either<string[], TinyFp.Unit>.Left(new[] { "a", "b" });
 
         var item = new TestModel();
         _mockManager.Setup(_ => _.ItemSatisfiesRulesWithMessage(item)).Returns(expected);

--- a/tests/LogicEngine.Unit.Tests/RulesManagerTests.cs
+++ b/tests/LogicEngine.Unit.Tests/RulesManagerTests.cs
@@ -17,10 +17,12 @@ public class RulesManagerTests
 {
     private Mock<IRulesCatalogCompiler> _mockCompiler;
     private RulesManager<TestModel> _sut;
+    private RulesCatalog _catalog;
 
     [SetUp]
     public void SetUp()
     {
+        _catalog = new RulesCatalog(new RulesSet[] { new() { Description = "ruleset #1", Rules = new[] { new Rule("property", Internals.OperatorType.Contains, "value") } } }, "name");
         _mockCompiler = new Mock<IRulesCatalogCompiler>();
         _sut = new RulesManager<TestModel>(_mockCompiler.Object);
     }
@@ -28,13 +30,12 @@ public class RulesManagerTests
     [Test]
     public void ItemSatisfiesRules_WhenCompilerReturnsNoElements_ShouldReturnTrue()
     {
-        var catalog = new RulesCatalog(It.IsAny<IEnumerable<RulesSet>>(), "name");
-        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(catalog))
+        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(_catalog))
             .Returns(new CompiledCatalog<TestModel>(Empty<Func<TestModel, Either<string, TinyFp.Unit>>[]>()));
 
         var item = new TestModel();
 
-        _sut.Catalog = catalog;
+        _sut.Catalog = _catalog;
 
         var result = _sut.ItemSatisfiesRules(item);
 
@@ -48,8 +49,7 @@ public class RulesManagerTests
     [Test]
     public void ItemSatisfiesRules_WhenCompilerReturnSuccessfulElements_ShouldReturnCorrespondingResult()
     {
-        var catalog = new RulesCatalog(It.IsAny<IEnumerable<RulesSet>>(), "name");
-        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(catalog))
+        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(_catalog))
             .Returns(new CompiledCatalog<TestModel>(new[]
             {
                 new Func<TestModel, Either<string, TinyFp.Unit>>[]
@@ -60,7 +60,7 @@ public class RulesManagerTests
 
         var item = new TestModel();
 
-        _sut.Catalog = catalog;
+        _sut.Catalog = _catalog;
 
         var result = _sut.ItemSatisfiesRules(item);
 
@@ -74,8 +74,7 @@ public class RulesManagerTests
     [Test]
     public void ItemSatisfiesRules_WhenCompilerReturnFailingElements_ShouldReturnCorrespondingResult()
     {
-        var catalog = new RulesCatalog(It.IsAny<IEnumerable<RulesSet>>(), "name");
-        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(catalog))
+        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(_catalog))
             .Returns(new CompiledCatalog<TestModel>(new[]
             {
                 new Func<TestModel, Either<string, TinyFp.Unit>>[]
@@ -86,7 +85,7 @@ public class RulesManagerTests
 
         var item = new TestModel();
 
-        _sut.Catalog = catalog;
+        _sut.Catalog = _catalog;
 
         var result = _sut.ItemSatisfiesRules(item);
 
@@ -102,8 +101,7 @@ public class RulesManagerTests
     [Test]
     public void ItemSatisfiesRulesWithMessage_WhenCompilerReturnsLeftValuedFunctionsWithEmptyCode_ShouldReturnEmptyCored()
     {
-        var catalog = new RulesCatalog(It.IsAny<IEnumerable<RulesSet>>(), "name");
-        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(catalog))
+        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(_catalog))
             .Returns(new CompiledCatalog<TestModel>(new[]
             {
                 new Func<TestModel, Either<string, TinyFp.Unit>>[]
@@ -114,7 +112,7 @@ public class RulesManagerTests
 
         var item = new TestModel();
 
-        _sut.Catalog = catalog;
+        _sut.Catalog = _catalog;
 
         var resultWithMessage = _sut.ItemSatisfiesRulesWithMessage(item);
 
@@ -126,9 +124,7 @@ public class RulesManagerTests
     [Test]
     public void When_FilterOnSetOfMatchingItems_ShouldReturnEquivalentResult()
     {
-        var catalog = new RulesCatalog(It.IsAny<IEnumerable<RulesSet>>(), "name");
-
-        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(catalog))
+        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(_catalog))
             .Returns(new CompiledCatalog<TestModel>(new[]
             {
                 new Func<TestModel, Either<string, TinyFp.Unit>>[]
@@ -172,9 +168,7 @@ public class RulesManagerTests
     [Test]
     public void When_FilterOnSetOfSomeMatchingItems_ShouldFilterThemOut()
     {
-        var catalog = new RulesCatalog(It.IsAny<IEnumerable<RulesSet>>(), "name");
-
-        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(catalog))
+        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(_catalog))
             .Returns(new CompiledCatalog<TestModel>(new[]
             {
                 new Func<TestModel, Either<string, TinyFp.Unit>>[]
@@ -191,7 +185,7 @@ public class RulesManagerTests
                 }
             }));
 
-        _sut.Catalog = catalog;
+        _sut.Catalog = _catalog;
         var items = new List<TestModel>
         {
             new()
@@ -227,9 +221,7 @@ public class RulesManagerTests
     [Test]
     public void When_FirstOrDefaultOnSetOfSomeMatchingItems_ShouldReturnFirst()
     {
-        var catalog = new RulesCatalog(It.IsAny<IEnumerable<RulesSet>>(), "name");
-
-        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(catalog))
+        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(_catalog))
             .Returns(new CompiledCatalog<TestModel>(new[]
             {
                 new Func<TestModel, Either<string, TinyFp.Unit>>[]
@@ -245,7 +237,7 @@ public class RulesManagerTests
                         () => Either<string, TinyFp.Unit>.Left(string.Empty))
                 }
             }));
-        _sut.Catalog = catalog;
+        _sut.Catalog = _catalog;
         var items = new List<TestModel>
         {
             new()
@@ -286,9 +278,7 @@ public class RulesManagerTests
     [Test]
     public void When_FirstOrDefaultOnSetOfNonMatchingItems_ShouldReturnDefault()
     {
-        var catalog = new RulesCatalog(It.IsAny<IEnumerable<RulesSet>>(), "name");
-
-        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(catalog))
+        _mockCompiler.Setup(_ => _.CompileCatalog<TestModel>(_catalog))
             .Returns(new CompiledCatalog<TestModel>(new[]
             {
                 new Func<TestModel, Either<string, TinyFp.Unit>>[]
@@ -304,7 +294,7 @@ public class RulesManagerTests
                         () => Either<string, TinyFp.Unit>.Left(string.Empty))
                 }
             }));
-        _sut.Catalog = catalog;
+        _sut.Catalog = _catalog;
         var items = new List<TestModel>
         {
             new()
@@ -335,5 +325,4 @@ public class RulesManagerTests
 
         result.Should().BeEquivalentTo(default(TestModel), options => options.ComparingByMembers<TestModel>());
     }
-
 }

--- a/tests/LogicEngine.Unit.Tests/RulesManagerTests.cs
+++ b/tests/LogicEngine.Unit.Tests/RulesManagerTests.cs
@@ -79,7 +79,7 @@ public class RulesManagerTests
             {
                 new Func<TestModel, Either<string, TinyFp.Unit>>[]
                 {
-                    _ => Either<string, TinyFp.Unit>.Left("code"),
+                    _ => Either<string, TinyFp.Unit>.Left("code")
                 }
             }));
 
@@ -95,7 +95,7 @@ public class RulesManagerTests
 
         resultWithMessage.IsLeft.Should().BeTrue();
 
-        resultWithMessage.OnLeft(_ => _.Should().BeEquivalentTo("code"));
+        resultWithMessage.OnLeft(_ => _.Should().BeEquivalentTo(new[] { "code" }));
     }
 
     [Test]


### PR DESCRIPTION
- loop code split into smaller methods
- loop avoid to call last time itself doing errorCodes check in advance
- once catalog is set, it is already possible to forecast ItemSatisfiesRules result instead to evaluate it every time

Catalog property actually does "many things", that behaviour could be split into different parts but preferred to keep PR small :) 