### PR TITLE
replaced tuple-based test sources with arrays

### DIFF
--- a/tests/LogicEngine.Unit.Tests/CompiledCatalogTests.cs
+++ b/tests/LogicEngine.Unit.Tests/CompiledCatalogTests.cs
@@ -12,105 +12,105 @@ public class CompiledCatalogTests
         // 0 false
         new object[]
         {
-            (true, true, true, true),
+            new[]{ true, true, true, true },
             true,
-            (true, true, false, false)
+            new[]{ true, true, false, false }
         },
         // 1 false
         new object[]
         {
-            (true, true, true, false),
+            new[]{ true, true, true, false },
             true,
-            (true, true, false, false)
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, true, false, true),
+            new[]{ true, true, false, true },
             true,
-            (true, true, false, false)
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, false, true, true),
+            new[]{ true, false, true, true },
             true,
-            (true, true, true, true)
+            new[]{ true, true, true, true }
         },
         new object[]
         {
-            (false, true, true, true),
+            new[]{ false, true, true, true },
             true,
-            (true, false, true, true)
+            new[]{ true, false, true, true }
         },
         // 2 false
         new object[]
         {
-            (true, true, false, false),
+            new[]{ true, true, false, false },
             true,
-            (true, true, false, false)
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, false, false, true),
+            new[]{ true, false, false, true },
             false,
-            (true, true, true, false)
+            new[]{ true, true, true, false }
         },
         new object[]
         {
-            (false, false, true, true),
+            new[]{ false, false, true, true },
             true,
-            (true, false, true, true)
+            new[]{ true, false, true, true }
         },
         new object[]
         {
-            (false, true, false, true),
+            new[]{ false, true, false, true },
             false,
-            (true, false, true, false)
+            new[]{ true, false, true, false }
         },
         new object[]
         {
-            (true, false, true, false),
+            new[]{ true, false, true, false },
             false,
-            (true, true, true, true)
+            new[]{ true, true, true, true }
         },
         // 3 false
         new object[]
         {
-            (true, false, false, false),
+            new[]{ true, false, false, false },
             false,
-            (true, true, true, false)
+            new[]{ true, true, true, false }
         },
         new object[]
         {
-            (false, false, true, false),
+            new[]{ false, false, true, false },
             false,
-            (true, false, true, true)
+            new[]{ true, false, true, true }
         },
         new object[]
         {
-            (false, true, false, false),
+            new[]{ false, true, false, false },
             false,
-            (true, false, true, false)
+            new[]{ true, false, true, false }
         },
         new object[]
         {
-            (false, false, false, true),
+            new[]{ false, false, false, true },
             false,
-            (true, false, true, false)
+            new[]{ true, false, true, false }
         },
         // 4 false
         new object[]
         {
-            (false, false, false, false),
+            new[]{ false, false, false, false },
             false,
-            (true, false, true, false)
+            new[]{ true, false, true, false }
         }
     };
 
     [TestCaseSource(nameof(ApplyTestSource))]
     public void Apply_WhenRulesSetsProvideDifferentResults_ShouldReturnExpectedResult(
-        (bool, bool, bool, bool) funcOutputs,
+        bool[] funcOutputs,
         bool expected,
-        (bool, bool, bool, bool) funcCalled)
+        bool[] funcCalled)
     {
         var called11 = false;
         var called12 = false;
@@ -121,13 +121,13 @@ public class CompiledCatalogTests
         {
             new CompiledRulesSet<TestModel>(new CompiledRule<TestModel>[]
             {
-                new (item => {called11 = true;  return funcOutputs.Item1; }, "code 1.1"),
-                new (item => {called12 = true;  return funcOutputs.Item2; }, "code 1.2")
+                new (item => {called11 = true;  return funcOutputs[0]; }, "code 1.1"),
+                new (item => {called12 = true;  return funcOutputs[1]; }, "code 1.2")
             }, "set 1"),
             new CompiledRulesSet<TestModel>(new CompiledRule<TestModel>[]
             {
-                new (item => {called21 = true;  return funcOutputs.Item3; }, "code 2.1"),
-                new (item => {called22 = true;  return funcOutputs.Item4; }, "code 2.2")
+                new (item => {called21 = true;  return funcOutputs[2]; }, "code 2.1"),
+                new (item => {called22 = true;  return funcOutputs[3]; }, "code 2.2")
             }, "set 2")
         };
 
@@ -137,61 +137,61 @@ public class CompiledCatalogTests
 
         sut.Apply(item).Should().Be(expected);
 
-        called11.Should().Be(funcCalled.Item1);
-        called12.Should().Be(funcCalled.Item2);
-        called21.Should().Be(funcCalled.Item3);
-        called22.Should().Be(funcCalled.Item4);
+        called11.Should().Be(funcCalled[0]);
+        called12.Should().Be(funcCalled[1]);
+        called21.Should().Be(funcCalled[2]);
+        called22.Should().Be(funcCalled[3]);
     }
 
     internal static object[] DetailedApplyFailingTestSource = new[]
     {
         new object[]
         {
-            (true, false, false, true),
+            new[]{ true, false, false, true },
             new[]{ "code 1.2", "code 2.1" }
         },
         new object[]
         {
-            (false, true, false, true),
+            new[]{ false, true, false, true },
             new[]{ "code 1.1", "code 2.1" }
         },
         new object[]
         {
-            (true, false, true, false),
+            new[]{ true, false, true, false },
             new[]{ "code 1.2", "code 2.2" }
         },
         // 3 false
         new object[]
         {
-            (true, false, false, false),
+            new[]{ true, false, false, false },
             new[]{ "code 1.2", "code 2.1", "code 2.2" }
         },
         new object[]
         {
-            (false, false, true, false),
+            new[]{ false, false, true, false },
             new[]{ "code 1.1", "code 1.2", "code 2.2" }
         },
         new object[]
         {
-            (false, true, false, false),
+            new[]{ false, true, false, false },
             new[]{ "code 1.1", "code 2.1", "code 2.2" }
         },
         new object[]
         {
-            (false, false, false, true),
+            new[]{ false, false, false, true },
             new[]{ "code 1.1", "code 1.2", "code 2.1" }
         },
         // 4 false
         new object[]
         {
-            (false, false, false, false),
+            new[]{ false, false, false, false },
             new[]{ "code 1.1", "code 1.2", "code 2.1", "code 2.2" }
         }
     };
 
     [TestCaseSource(nameof(DetailedApplyFailingTestSource))]
     public void DetailedApply_WhenRulesSetIsNotSuccessful_ShouldReturnExpectedCodes(
-        (bool, bool, bool, bool) funcOutputs,
+        bool[] funcOutputs,
         IEnumerable<string> expected
         )
     {
@@ -204,13 +204,13 @@ public class CompiledCatalogTests
         {
             new CompiledRulesSet<TestModel>(new CompiledRule<TestModel>[]
             {
-                new (item => {called11 = true;  return funcOutputs.Item1; }, "code 1.1"),
-                new (item => {called12 = true;  return funcOutputs.Item2; }, "code 1.2")
+                new (item => {called11 = true;  return funcOutputs[0]; }, "code 1.1"),
+                new (item => {called12 = true;  return funcOutputs[1]; }, "code 1.2")
             }, "set 1"),
             new CompiledRulesSet<TestModel>(new CompiledRule<TestModel>[]
             {
-                new (item => {called21 = true;  return funcOutputs.Item3; }, "code 2.1"),
-                new (item => {called22 = true;  return funcOutputs.Item4; }, "code 2.2")
+                new (item => {called21 = true;  return funcOutputs[2]; }, "code 2.1"),
+                new (item => {called22 = true;  return funcOutputs[3]; }, "code 2.2")
             }, "set 2")
         };
 
@@ -232,45 +232,45 @@ public class CompiledCatalogTests
     {
         new object[]
         {
-            (true, true, true, true),
-            (true, true, false, false)
+            new[]{ true, true, true, true },
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, true, true, false),
-            (true, true, false, false)
+            new[]{ true, true, true, false },
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, true, false, true),
-            (true, true, false, false)
+            new[]{ true, true, false, true },
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, false, true, true),
-            (true, true, true, true)
+            new[]{ true, false, true, true },
+            new[]{ true, true, true, true }
         },
         new object[]
         {
-            (false, true, true, true),
-            (true, false, true, true)
+            new[]{ false, true, true, true },
+            new[]{ true, false, true, true }
         },
         new object[]
         {
-            (true, true, false, false),
-            (true, true, false, false)
+            new[]{ true, true, false, false },
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (false, false, true, true),
-            (true, false, true, true)
+            new[]{ false, false, true, true },
+            new[]{ true, false, true, true }
         }
     };
 
     [TestCaseSource(nameof(DetailedApplySuccessfullTestSource))]
     public void DetailedApply_WhenRulesSetIsSuccessful_ShouldReturnRight(
-        (bool, bool, bool, bool) funcOutputs,
-        (bool, bool, bool, bool) funcCalled)
+        bool[] funcOutputs,
+        bool[] funcCalled)
     {
         var called11 = false;
         var called12 = false;
@@ -281,13 +281,13 @@ public class CompiledCatalogTests
         {
             new CompiledRulesSet<TestModel>(new CompiledRule<TestModel>[]
             {
-                new (item => {called11 = true;  return funcOutputs.Item1; }, "code 1.1"),
-                new (item => {called12 = true;  return funcOutputs.Item2; }, "code 1.2")
+                new (item => {called11 = true;  return funcOutputs[0]; }, "code 1.1"),
+                new (item => {called12 = true;  return funcOutputs[1]; }, "code 1.2")
             }, "set 1"),
             new CompiledRulesSet<TestModel>(new CompiledRule<TestModel>[]
             {
-                new (item => {called21 = true;  return funcOutputs.Item3; }, "code 2.1"),
-                new (item => {called22 = true;  return funcOutputs.Item4; }, "code 2.2")
+                new (item => {called21 = true;  return funcOutputs[2]; }, "code 2.1"),
+                new (item => {called22 = true;  return funcOutputs[3]; }, "code 2.2")
             }, "set 2")
         };
 
@@ -297,117 +297,117 @@ public class CompiledCatalogTests
 
         sut.DetailedApply(item).IsRight.Should().BeTrue();
 
-        called11.Should().Be(funcCalled.Item1);
-        called12.Should().Be(funcCalled.Item2);
-        called21.Should().Be(funcCalled.Item3);
-        called22.Should().Be(funcCalled.Item4);
+        called11.Should().Be(funcCalled[0]);
+        called12.Should().Be(funcCalled[1]);
+        called21.Should().Be(funcCalled[2]);
+        called22.Should().Be(funcCalled[3]);
     }
 
     internal static object[] FirstMatchingTestSource = new[]
     {
         new object[]
         {
-            (false, false, false, false),
+            new[]{ false, false, false, false },
             Option<string>.None(),
-            (true, false, true, false)
+            new[]{ true, false, true, false }
         },
         new object[]
         {
-            (true, false, false, false),
+            new[]{ true, false, false, false },
             Option<string>.None(),
-            (true, true, true, false)
+            new[]{ true, true, true, false }
         },
         new object[]
         {
-            (false, true, false, false),
+            new[]{ false, true, false, false },
             Option<string>.None(),
-            (true, false, true, false)
+            new[]{ true, false, true, false }
         },
         new object[]
         {
-            (false, false, true, false),
+            new[]{ false, false, true, false },
             Option<string>.None(),
-            (true, false, true, true)
+            new[]{ true, false, true, true }
         },
         new object[]
         {
-            (false, false, false, true),
+            new[]{ false, false, false, true },
             Option<string>.None(),
-            (true, false, true, false)
+            new[]{ true, false, true, false }
         },
         new object[]
         {
-            (true, true, false, false),
+            new[]{ true, true, false, false },
             Option<string>.Some("set 1"),
-            (true, true, false, false)
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, false, true, false),
+            new[]{ true, false, true, false },
             Option<string>.None(),
-            (true, true, true, true)
+            new[]{ true, true, true, true }
         },
         new object[]
         {
-            (false, true, true, false),
+            new[]{ false, true, true, false },
             Option<string>.None(),
-            (true, false, true, true)
+            new[]{ true, false, true, true }
         },
         new object[]
         {
-            (true, false, false, true),
+            new[]{ true, false, false, true },
             Option<string>.None(),
-            (true, true, true, false)
+            new[]{ true, true, true, false }
         },
         new object[]
         {
-            (false, true, false, true),
+            new[]{ false, true, false, true },
             Option<string>.None(),
-            (true, false, true, false)
+            new[]{ true, false, true, false }
         },
         new object[]
         {
-            (false, false, true, true),
+            new[]{ false, false, true, true },
             Option<string>.Some("set 2"),
-            (true, false, true, true)
+            new[]{ true, false, true, true }
         },
         new object[]
         {
-            (true, true, true, false),
+            new[]{ true, true, true, false },
             Option<string>.Some("set 1"),
-            (true, true, false, false)
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, true, false, true),
+            new[]{ true, true, false, true },
             Option<string>.Some("set 1"),
-            (true, true, false, false)
+            new[]{ true, true, false, false }
         },
         new object[]
         {
-            (true, false, true, true),
+            new[]{ true, false, true, true },
             Option<string>.Some("set 2"),
-            (true, true, true, true)
+            new[]{ true, true, true, true }
         },
         new object[]
         {
-            (false, true, true, true),
+            new[]{ false, true, true, true },
             Option<string>.Some("set 2"),
-            (true, false, true, true)
+            new[]{ true, false, true, true }
         },
         new object[]
         {
-            (true, true, true, true),
+            new[]{ true, true, true, true },
             Option<string>.Some("set 1"),
-            (true, true, false, false)
+            new[]{ true, true, false, false }
         }
     };
 
     [TestCaseSource(nameof(FirstMatchingTestSource))]
     public void FirstMatching_ShouldReturnExpectedValue(
-            (bool, bool, bool, bool) funcOutputs,
+            bool[] funcOutputs,
             Option<string> expected,
-            (bool, bool, bool, bool) funcCalled)
+            bool[] funcCalled)
     {
         var called11 = false;
         var called12 = false;
@@ -418,13 +418,13 @@ public class CompiledCatalogTests
         {
             new CompiledRulesSet<TestModel>(new CompiledRule<TestModel>[]
             {
-                new (item => {called11 = true;  return funcOutputs.Item1; }, "code 1.1"),
-                new (item => {called12 = true;  return funcOutputs.Item2; }, "code 1.2")
+                new (item => {called11 = true;  return funcOutputs[0]; }, "code 1.1"),
+                new (item => {called12 = true;  return funcOutputs[1]; }, "code 1.2")
             }, "set 1"),
             new CompiledRulesSet<TestModel>(new CompiledRule<TestModel>[]
             {
-                new (item => {called21 = true;  return funcOutputs.Item3; }, "code 2.1"),
-                new (item => {called22 = true;  return funcOutputs.Item4; }, "code 2.2")
+                new (item => {called21 = true;  return funcOutputs[2]; }, "code 2.1"),
+                new (item => {called22 = true;  return funcOutputs[3]; }, "code 2.2")
             }, "set 2")
         };
 
@@ -434,9 +434,9 @@ public class CompiledCatalogTests
 
         sut.FirstMatching(item).Should().Be(expected);
 
-        called11.Should().Be(funcCalled.Item1);
-        called12.Should().Be(funcCalled.Item2);
-        called21.Should().Be(funcCalled.Item3);
-        called22.Should().Be(funcCalled.Item4);
+        called11.Should().Be(funcCalled[0]);
+        called12.Should().Be(funcCalled[1]);
+        called21.Should().Be(funcCalled[2]);
+        called22.Should().Be(funcCalled[3]);
     }
 }

--- a/tests/LogicEngine.Unit.Tests/CompiledRulesSetTests.cs
+++ b/tests/LogicEngine.Unit.Tests/CompiledRulesSetTests.cs
@@ -10,50 +10,50 @@ public class CompiledRulesSetTests
     {
         new object[]
         {
-            (true, true, true),
+            new[]{ true, true, true },
             true,
-            (true, true, true)
+            new[]{ true, true, true }
         },
         new object[]
         {
-            (true, true, false),
+            new[]{ true, true, false },
             false,
-            (true, true, true)
+            new[]{ true, true, true }
         },
         new object[]
         {
-            (true, false, true),
+            new[]{ true, false, true },
             false,
-            (true, true, false)
+            new[]{ true, true, false }
         },
         new object[]
         {
-            (false, true, true),
+            new[]{ false, true, true },
             false,
-            (true, false, false)
+            new[]{ true, false, false }
         },
         new object[]
         {
-            (true, false, false),
+            new[] { true, false, false },
             false,
-            (true, true, false)
+            new[]{ true, true, false }
         },
         new object[]
         {
-            (false, true, false),
+            new[] { false, true, false },
             false,
-            (true, false, false)
+            new[] { true, false, false }
         },
         new object[]
         {
-            (false, false, true),
+            new[] { false, false, true },
             false,
-            (true, false, false)
+            new[] { true, false, false }
         }
     };
 
     [TestCaseSource(nameof(ApplyTestSource))]
-    public void Apply_WhenCompiledRulesReturnDifferentValues_ShouldReturnExpectedResults((bool, bool, bool) funcOutputs, bool expected, (bool, bool, bool) expectedFuncCalls)
+    public void Apply_WhenCompiledRulesReturnDifferentValues_ShouldReturnExpectedResults(bool[] funcOutputs, bool expected, bool[] expectedFuncCalls)
     {
         var called1 = false;
         var called2 = false;
@@ -64,17 +64,17 @@ public class CompiledRulesSetTests
             new (item =>
             {
                 called1 = true;
-                return funcOutputs.Item1;
+                return funcOutputs[0];
             }, "code 1"),
             new (item =>
             {
                 called2 = true;
-                return funcOutputs.Item2;
+                return funcOutputs[1];
             }, "code 2"),
             new (item =>
             {
                 called3 = true;
-                return funcOutputs.Item3;
+                return funcOutputs[2];
             }, "code 3")
         };
 
@@ -84,52 +84,52 @@ public class CompiledRulesSetTests
 
         sut.Apply(item).Should().Be(expected);
 
-        called1.Should().Be(expectedFuncCalls.Item1);
-        called2.Should().Be(expectedFuncCalls.Item2);
-        called3.Should().Be(expectedFuncCalls.Item3);
+        called1.Should().Be(expectedFuncCalls[0]);
+        called2.Should().Be(expectedFuncCalls[1]);
+        called3.Should().Be(expectedFuncCalls[2]);
     }
 
     internal static object[] DetailedApplyTestSource = new[]
     {
         new object[]
         {
-            (false, false, false),
+            new[] { false, false, false },
             new[] { "code 1", "code 2", "code 3" }
         },
         new object[]
         {
-            (true, false, false),
+            new[] { true, false, false },
             new[] { "code 2", "code 3" }
         },
         new object[]
         {
-            (false, true, false),
+            new[] { false, true, false },
             new[] { "code 1", "code 3" }
         },
         new object[]
         {
-            (false, false, true),
+            new[] { false, false, true },
             new[] { "code 1", "code 2" }
         },
         new object[]
         {
-            (false, true, true),
+            new[] { false, true, true },
             new[] { "code 1" }
         },
         new object[]
         {
-            (true, false, true),
+            new[] { true, false, true },
             new[] { "code 2" }
         },
         new object[]
         {
-            (true, true, false),
+            new[] { true, true, false },
             new[] { "code 3" }
         }
     };
 
     [TestCaseSource(nameof(DetailedApplyTestSource))]
-    public void DetailedApply_WhenSomeRuleIsNotSatisfied_ShouldReturnLeft((bool, bool, bool) funcOutputs, string[] expected)
+    public void DetailedApply_WhenSomeRuleIsNotSatisfied_ShouldReturnLeft(bool[] funcOutputs, string[] expected)
     {
         var called1 = false;
         var called2 = false;
@@ -140,17 +140,17 @@ public class CompiledRulesSetTests
             new (item =>
             {
                 called1 = true;
-                return funcOutputs.Item1;
+                return funcOutputs[0];
             }, "code 1"),
             new (item =>
             {
                 called2 = true;
-                return funcOutputs.Item2;
+                return funcOutputs[1];
             }, "code 2"),
             new (item =>
             {
                 called3 = true;
-                return funcOutputs.Item3;
+                return funcOutputs[2];
             }, "code 3")
         };
 
@@ -172,56 +172,56 @@ public class CompiledRulesSetTests
     {
         new object[]
         {
-            (false, false, false),
+            new[] { false, false, false },
             Option<string>.None(),
-            (true, true, true)
+            new[] { true, true, true }
         },
         new object[]
         {
-            (true, false, false),
+            new[] { true, false, false },
             Option<string>.Some("code 1"),
-            (true, false, false)
+            new[] { true, false, false }
         },
         new object[]
         {
-            (false, true, false),
+            new[] { false, true, false },
             Option<string>.Some("code 2"),
-            (true, true, false)
+            new[] { true, true, false }
         },
         new object[]
         {
-            (false, false, true),
+            new[] { false, false, true },
             Option<string>.Some("code 3"),
-            (true, true, true)
+            new[] { true, true, true }
         },
         new object[]
         {
-            (false, true, true),
+            new[] { false, true, true },
             Option<string>.Some("code 2"),
-            (true, true, false)
+            new[] { true, true, false }
         },
         new object[]
         {
-            (true, false, true),
+            new[] { true, false, true },
             Option<string>.Some("code 1"),
-            (true, false, false)
+            new[] { true, false, false }
         },
         new object[]
         {
-            (true, true, false),
+            new[] { true, true, false },
             Option<string>.Some("code 1"),
-            (true, false, false)
+            new[] { true, false, false }
         },
         new object[]
         {
-            (true, true, true),
+            new[] { true, true, true },
             Option<string>.Some("code 1"),
-            (true, false, false)
+            new[] { true, false, false }
         }
     };
 
     [TestCaseSource(nameof(FirstMatchingTestSource))]
-    public void FirstMatching_ShouldReturnExpectedValue((bool, bool, bool) funcOutputs, Option<string> expected, (bool, bool, bool) expectedFuncCalls)
+    public void FirstMatching_ShouldReturnExpectedValue(bool[] funcOutputs, Option<string> expected, bool[] expectedFuncCalls)
     {
         var called1 = false;
         var called2 = false;
@@ -232,17 +232,17 @@ public class CompiledRulesSetTests
             new (item =>
             {
                 called1 = true;
-                return funcOutputs.Item1;
+                return funcOutputs[0];
             }, "code 1"),
             new (item =>
             {
                 called2 = true;
-                return funcOutputs.Item2;
+                return funcOutputs[1];
             }, "code 2"),
             new (item =>
             {
                 called3 = true;
-                return funcOutputs.Item3;
+                return funcOutputs[2];
             }, "code 3")
         };
 
@@ -254,8 +254,8 @@ public class CompiledRulesSetTests
             .FirstMatching(item)
             .Should().BeEquivalentTo(expected);
 
-        called1.Should().Be(expectedFuncCalls.Item1);
-        called2.Should().Be(expectedFuncCalls.Item2);
-        called3.Should().Be(expectedFuncCalls.Item3);
+        called1.Should().Be(expectedFuncCalls[0]);
+        called2.Should().Be(expectedFuncCalls[1]);
+        called3.Should().Be(expectedFuncCalls[2]);
     }
 }


### PR DESCRIPTION
NUnit testcasesources with tuples do not work in VS IDE.
Replaced them with arrays.