### PR TITLE
refactor unit tests to use Shouldly assertions instead of FluentAssertions

### DIFF
--- a/tests/LogicEngine.Unit.Tests/CatalogCompositionTests.cs
+++ b/tests/LogicEngine.Unit.Tests/CatalogCompositionTests.cs
@@ -24,8 +24,8 @@ public class CatalogCompositionTests
 
         var sumCatalog = c1 + c2;
 
-        sumCatalog.RulesSets.Should().HaveCount(ruleSets1 + ruleSets2);
-        sumCatalog.Name.Should().Be("(name 1 OR name 2)");
+        sumCatalog.RulesSets.Count().ShouldBe(ruleSets1 + ruleSets2);
+        sumCatalog.Name.ShouldBe("(name 1 OR name 2)");
     }
 
     [TestCase(0, 0)]
@@ -45,8 +45,8 @@ public class CatalogCompositionTests
 
         var sumCatalog = c1 * c2;
 
-        sumCatalog.RulesSets.Should().HaveCount(ruleSets1 * ruleSets2);
-        sumCatalog.Name.Should().Be("(name 1 AND name 2)");
+        sumCatalog.RulesSets.Count().ShouldBe(ruleSets1 * ruleSets2);
+        sumCatalog.Name.ShouldBe("(name 1 AND name 2)");
     }
 
     [Test]
@@ -66,13 +66,13 @@ public class CatalogCompositionTests
 
         var sumCatalog1 = c1 + c2;
 
-        sumCatalog1.RulesSets.Should().HaveCount(1);
-        sumCatalog1.Name.Should().Be("(catalog 1 OR catalog 2)");
+        sumCatalog1.RulesSets.Count().ShouldBe(1);
+        sumCatalog1.Name.ShouldBe("(catalog 1 OR catalog 2)");
 
         var sumCatalog2 = c2 + c1;
 
-        sumCatalog2.RulesSets.Should().HaveCount(1);
-        sumCatalog2.Name.Should().Be("(catalog 2 OR catalog 1)");
+        sumCatalog2.RulesSets.Count().ShouldBe(1);
+        sumCatalog2.Name.ShouldBe("(catalog 2 OR catalog 1)");
     }
 
     [TestCase(0)]
@@ -88,13 +88,13 @@ public class CatalogCompositionTests
 
         var prodCatalog1 = c1 * c2;
 
-        prodCatalog1.RulesSets.Should().HaveCount(0);
-        prodCatalog1.Name.Should().Be("(catalog 1 AND catalog 2)");
+        prodCatalog1.RulesSets.Count().ShouldBe(0);
+        prodCatalog1.Name.ShouldBe("(catalog 1 AND catalog 2)");
 
         var prodCatalog2 = c2 * c1;
 
-        prodCatalog2.RulesSets.Should().HaveCount(0);
-        prodCatalog2.Name.Should().Be("(catalog 2 AND catalog 1)");
+        prodCatalog2.RulesSets.Count().ShouldBe(0);
+        prodCatalog2.Name.ShouldBe("(catalog 2 AND catalog 1)");
 
     }
 
@@ -106,7 +106,7 @@ public class CatalogCompositionTests
 
         var prodCatalog1 = c1 * c2;
 
-        prodCatalog1.RulesSets.Should().HaveCount(0);
-        prodCatalog1.Name.Should().Be("(catalog 1 AND catalog 2)");
+        prodCatalog1.RulesSets.Count().ShouldBe(0);
+        prodCatalog1.Name.ShouldBe("(catalog 1 AND catalog 2)");
     }
 }

--- a/tests/LogicEngine.Unit.Tests/CompiledCatalogTests.cs
+++ b/tests/LogicEngine.Unit.Tests/CompiledCatalogTests.cs
@@ -121,12 +121,12 @@ public class CompiledCatalogTests
 
         var item = new AutoFaker<TestModel>().Generate();
 
-        sut.Apply(item).Should().Be(expected);
+        sut.Apply(item).ShouldBe(expected);
 
-        called11.Should().Be(funcCalled[0]);
-        called12.Should().Be(funcCalled[1]);
-        called21.Should().Be(funcCalled[2]);
-        called22.Should().Be(funcCalled[3]);
+        called11.ShouldBe(funcCalled[0]);
+        called12.ShouldBe(funcCalled[1]);
+        called21.ShouldBe(funcCalled[2]);
+        called22.ShouldBe(funcCalled[3]);
     }
 
     internal static object[] DetailedApplyFailingTestSource = new[]
@@ -198,13 +198,13 @@ public class CompiledCatalogTests
         var item = new AutoFaker<TestModel>().Generate();
 
         sut.DetailedApply(item)
-            .Tee(e => e.IsLeft.Should().BeTrue())
-            .OnLeft(e => e.Should().BeEquivalentTo(expected));
+            .Tee(e => e.IsLeft.ShouldBeTrue())
+            .OnLeft(e => e.ShouldBe(expected));
 
-        called11.Should().BeTrue();
-        called12.Should().BeTrue();
-        called21.Should().BeTrue();
-        called22.Should().BeTrue();
+        called11.ShouldBeTrue();
+        called12.ShouldBeTrue();
+        called21.ShouldBeTrue();
+        called22.ShouldBeTrue();
     }
 
     internal static object[] DetailedApplySuccessfullTestSource = new[]
@@ -268,12 +268,12 @@ public class CompiledCatalogTests
 
         var item = new AutoFaker<TestModel>().Generate();
 
-        sut.DetailedApply(item).IsRight.Should().BeTrue();
+        sut.DetailedApply(item).IsRight.ShouldBeTrue();
 
-        called11.Should().Be(funcCalled[0]);
-        called12.Should().Be(funcCalled[1]);
-        called21.Should().Be(funcCalled[2]);
-        called22.Should().Be(funcCalled[3]);
+        called11.ShouldBe(funcCalled[0]);
+        called12.ShouldBe(funcCalled[1]);
+        called21.ShouldBe(funcCalled[2]);
+        called22.ShouldBe(funcCalled[3]);
     }
 
     internal static object[] FirstMatchingTestSource = new[]
@@ -390,11 +390,11 @@ public class CompiledCatalogTests
 
         var item = new AutoFaker<TestModel>().Generate();
 
-        sut.FirstMatching(item).Should().Be(expected);
+        sut.FirstMatching(item).ShouldBe(expected);
 
-        called11.Should().Be(funcCalled[0]);
-        called12.Should().Be(funcCalled[1]);
-        called21.Should().Be(funcCalled[2]);
-        called22.Should().Be(funcCalled[3]);
+        called11.ShouldBe(funcCalled[0]);
+        called12.ShouldBe(funcCalled[1]);
+        called21.ShouldBe(funcCalled[2]);
+        called22.ShouldBe(funcCalled[3]);
     }
 }

--- a/tests/LogicEngine.Unit.Tests/CompiledRuleTests.cs
+++ b/tests/LogicEngine.Unit.Tests/CompiledRuleTests.cs
@@ -14,9 +14,9 @@ public class CompiledRuleTests
 
         var item = new AutoFaker<TestModel>().Generate();
 
-        rule.Apply(item).Should().Be(returnValue);
+        rule.Apply(item).ShouldBe(returnValue);
 
-        timesCalled.Should().Be(1);
+        timesCalled.ShouldBe(1);
     }
 
     [Test]
@@ -28,9 +28,9 @@ public class CompiledRuleTests
 
         var item = new AutoFaker<TestModel>().Generate();
 
-        rule.DetailedApply(item).IsRight.Should().BeTrue();
+        rule.DetailedApply(item).IsRight.ShouldBeTrue();
 
-        timesCalled.Should().Be(1);
+        timesCalled.ShouldBe(1);
     }
 
     [Test]
@@ -42,8 +42,8 @@ public class CompiledRuleTests
 
         var item = new AutoFaker<TestModel>().Generate();
 
-        rule.DetailedApply(item).Tee(e => e.IsLeft.Should().BeTrue()).OnLeft(s => s.Should().Be("some code"));
+        rule.DetailedApply(item).Tee(e => e.IsLeft.ShouldBeTrue()).OnLeft(s => s.ShouldBe("some code"));
 
-        timesCalled.Should().Be(1);
+        timesCalled.ShouldBe(1);
     }
 }

--- a/tests/LogicEngine.Unit.Tests/CompiledRulesSetTests.cs
+++ b/tests/LogicEngine.Unit.Tests/CompiledRulesSetTests.cs
@@ -76,11 +76,11 @@ public class CompiledRulesSetTests
 
         var item = new AutoFaker<TestModel>().Generate();
 
-        sut.Apply(item).Should().Be(expected);
+        sut.Apply(item).ShouldBe(expected);
 
-        called1.Should().Be(expectedFuncCalls[0]);
-        called2.Should().Be(expectedFuncCalls[1]);
-        called3.Should().Be(expectedFuncCalls[2]);
+        called1.ShouldBe(expectedFuncCalls[0]);
+        called2.ShouldBe(expectedFuncCalls[1]);
+        called3.ShouldBe(expectedFuncCalls[2]);
     }
 
     internal static object[] DetailedApplyTestSource = new[]
@@ -148,12 +148,12 @@ public class CompiledRulesSetTests
 
         sut
             .DetailedApply(item)
-            .Tee(e => e.IsLeft.Should().BeTrue())
-            .OnLeft(e => e.Should().BeEquivalentTo(expected));
+            .Tee(e => e.IsLeft.ShouldBeTrue())
+            .OnLeft(e => e.ShouldBe(expected));
 
-        called1.Should().Be(true);
-        called2.Should().Be(true);
-        called3.Should().Be(true);
+        called1.ShouldBe(true);
+        called2.ShouldBe(true);
+        called3.ShouldBe(true);
     }
 
     internal static object[] FirstMatchingTestSource = new[]
@@ -233,10 +233,10 @@ public class CompiledRulesSetTests
 
         sut
             .FirstMatching(item)
-            .Should().BeEquivalentTo(expected);
+            .ShouldBeEquivalentTo(expected);
 
-        called1.Should().Be(expectedFuncCalls[0]);
-        called2.Should().Be(expectedFuncCalls[1]);
-        called3.Should().Be(expectedFuncCalls[2]);
+        called1.ShouldBe(expectedFuncCalls[0]);
+        called2.ShouldBe(expectedFuncCalls[1]);
+        called3.ShouldBe(expectedFuncCalls[2]);
     }
 }

--- a/tests/LogicEngine.Unit.Tests/Compilers/RuleCompilerTests.cs
+++ b/tests/LogicEngine.Unit.Tests/Compilers/RuleCompilerTests.cs
@@ -52,7 +52,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.Equal)]
@@ -67,7 +67,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.StringStartsWith)]
@@ -80,7 +80,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.StringStartsWith)]
@@ -93,7 +93,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.Equal)]
@@ -104,7 +104,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.Contains)]
@@ -115,7 +115,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.InnerEqual)]
@@ -130,7 +130,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.InnerEqual)]
@@ -145,7 +145,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.InnerContains, nameof(TestModel.IntEnumerableProperty), nameof(TestModel.IntProperty))]
@@ -162,7 +162,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [TestCase("IntEnumerableProperty", "1,2", OperatorType.Overlaps, true)]
@@ -182,7 +182,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().Be(expectedSome);
+        result.IsSome.ShouldBe(expectedSome);
     }
 
     [TestCase(OperatorType.ContainsKey)]
@@ -195,7 +195,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.KeyContainsValue)]
@@ -206,7 +206,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.InnerContains)]
@@ -219,7 +219,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 
     [TestCase(OperatorType.IsContained)]
@@ -230,7 +230,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [Test]
@@ -240,7 +240,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 
     [Test]
@@ -250,7 +250,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
     }
 
     [Test]
@@ -260,18 +260,18 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 13
-            }).IsLeft.Should().BeTrue();
+            }).IsLeft.ShouldBeTrue();
         });
     }
 
@@ -282,18 +282,18 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12
-            }).IsLeft.Should().BeTrue();
+            }).IsLeft.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 13
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -304,18 +304,18 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12
-            }).IsLeft.Should().BeTrue();
+            }).IsLeft.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 13
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -326,18 +326,18 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 13
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -348,7 +348,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -357,14 +357,14 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 11
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -372,8 +372,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -385,18 +385,18 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 11
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -404,8 +404,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -417,26 +417,26 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             var expectedLeft1 = cr.DetailedApply(new TestModel
             {
                 StringProperty = "shouldbeleftStringCased_"
             });
-            expectedLeft1.IsLeft.Should().BeTrue();
-            expectedLeft1.UnwrapLeft().Should().Be("string does not start with StringCased_");
+            expectedLeft1.IsLeft.ShouldBeTrue();
+            expectedLeft1.UnwrapLeft().ShouldBe("string does not start with StringCased_");
             var expectedLeft2 = cr.DetailedApply(new TestModel
             {
                 StringProperty = null
             });
-            expectedLeft2.IsLeft.Should().BeTrue();
-            expectedLeft2.UnwrapLeft().Should().Be("string does not start with StringCased_");
+            expectedLeft2.IsLeft.ShouldBeTrue();
+            expectedLeft2.UnwrapLeft().ShouldBe("string does not start with StringCased_");
 
             cr.DetailedApply(new TestModel
             {
                 StringProperty = "StringCased_teststring"
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -447,26 +447,26 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             var expectedLeft1 = cr.DetailedApply(new TestModel
             {
                 StringProperty = "should_StringCasedbeleft"
             });
-            expectedLeft1.IsLeft.Should().BeTrue();
-            expectedLeft1.UnwrapLeft().Should().Be("string does not end with _StringCased");
+            expectedLeft1.IsLeft.ShouldBeTrue();
+            expectedLeft1.UnwrapLeft().ShouldBe("string does not end with _StringCased");
             var expectedLeft2 = cr.DetailedApply(new TestModel
             {
                 StringProperty = null
             });
-            expectedLeft2.IsLeft.Should().BeTrue();
-            expectedLeft2.UnwrapLeft().Should().Be("string does not end with _StringCased");
+            expectedLeft2.IsLeft.ShouldBeTrue();
+            expectedLeft2.UnwrapLeft().ShouldBe("string does not end with _StringCased");
 
             cr.DetailedApply(new TestModel
             {
                 StringProperty = "teststring_StringCased"
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -477,26 +477,26 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             var expectedLeft1 = cr.DetailedApply(new TestModel
             {
                 StringProperty = "StringCase_should_StringCasedbeleft_StringCased"
             });
-            expectedLeft1.IsLeft.Should().BeTrue();
-            expectedLeft1.UnwrapLeft().Should().Be("string does not contain _StringCased_");
+            expectedLeft1.IsLeft.ShouldBeTrue();
+            expectedLeft1.UnwrapLeft().ShouldBe("string does not contain _StringCased_");
             var expectedLeft2 = cr.DetailedApply(new TestModel
             {
                 StringProperty = null
             });
-            expectedLeft2.IsLeft.Should().BeTrue();
-            expectedLeft2.UnwrapLeft().Should().Be("string does not contain _StringCased_");
+            expectedLeft2.IsLeft.ShouldBeTrue();
+            expectedLeft2.UnwrapLeft().ShouldBe("string does not contain _StringCased_");
 
             cr.DetailedApply(new TestModel
             {
                 StringProperty = "StringCased_should_StringCased_beleft_StringCased"
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -507,26 +507,26 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             var expectedLeft1 = cr.DetailedApply(new TestModel
             {
                 StringProperty = "feiwufuih sfojiwoej pwjiejfpo kjkjkkkk ejwijfdarn fjeqijfp o"
             });
-            expectedLeft1.IsLeft.Should().BeTrue();
-            expectedLeft1.UnwrapLeft().Should().Be("string does not match regex (?i)(\\W|^)(baloney|darn)(\\W|$)");
+            expectedLeft1.IsLeft.ShouldBeTrue();
+            expectedLeft1.UnwrapLeft().ShouldBe("string does not match regex (?i)(\\W|^)(baloney|darn)(\\W|$)");
             var expectedLeft2 = cr.DetailedApply(new TestModel
             {
                 StringProperty = null
             });
-            expectedLeft2.IsLeft.Should().BeTrue();
-            expectedLeft2.UnwrapLeft().Should().Be("string does not match regex (?i)(\\W|^)(baloney|darn)(\\W|$)");
+            expectedLeft2.IsLeft.ShouldBeTrue();
+            expectedLeft2.UnwrapLeft().ShouldBe("string does not match regex (?i)(\\W|^)(baloney|darn)(\\W|$)");
 
             cr.DetailedApply(new TestModel
             {
                 StringProperty = "feiwufuih sfojiwoej pwjiejfpo kjkjkkkk ejwijf darn fjeqijfp o"
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -537,13 +537,13 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntEnumerableProperty = [11, 12, 13]
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -551,8 +551,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -564,7 +564,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -573,14 +573,14 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
             {
                 IntEnumerableProperty = [11, 13]
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -591,18 +591,18 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntEnumerableProperty = [11, 12, 13]
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntEnumerableProperty = [11, 13]
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
         });
     }
 
@@ -613,7 +613,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -622,8 +622,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -632,8 +632,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -645,7 +645,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -655,7 +655,7 @@ public class RuleCompilerTests
                     {"my_key", "my_value"},
                     {"another_key", "another_value"},
                 }
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -667,15 +667,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -687,7 +687,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -700,8 +700,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -711,9 +711,9 @@ public class RuleCompilerTests
                     {"my_wrong_key", "my_value"},
                     {"another_key", "another_value"},
                 }
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -724,7 +724,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -734,7 +734,7 @@ public class RuleCompilerTests
                     {"my_key", "my_value"},
                     {"another_key", "another_value"},
                 }
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -746,15 +746,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -766,7 +766,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -779,8 +779,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -790,9 +790,9 @@ public class RuleCompilerTests
                     {"my_wrong_key", "my_wrong_value"},
                     {"another_key", "another_value"},
                 }
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -803,7 +803,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -813,7 +813,7 @@ public class RuleCompilerTests
                     { "my_key", "my_value" },
                     { "another_key", "another_value" },
                 }
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -825,8 +825,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -839,15 +839,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -859,7 +859,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -872,8 +872,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -883,7 +883,7 @@ public class RuleCompilerTests
                     { "my_key", "my_wrong_value" },
                     { "another_key", "another_value" },
                 }
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -892,9 +892,9 @@ public class RuleCompilerTests
                     {"my_wrong_key", "my_wrong_value"},
                     {"another_key", "another_value"},
                 }
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -905,13 +905,13 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -919,15 +919,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -939,7 +939,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -948,16 +948,16 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -968,21 +968,21 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12,
                 IntProperty2 = 12
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -993,14 +993,14 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12,
                 IntProperty2 = 12
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -1009,8 +1009,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -1019,11 +1019,11 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -1034,7 +1034,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -1044,8 +1044,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -1054,15 +1054,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -1074,7 +1074,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -1084,26 +1084,26 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14,
                 IntProperty2 = 13
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -1115,7 +1115,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -1125,26 +1125,26 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14,
                 IntProperty2 = 13
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -1156,27 +1156,27 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12,
                 IntProperty2 = 12
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14,
                 IntProperty2 = 13
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -1187,7 +1187,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -1197,15 +1197,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 13,
                 IntProperty2 = 14
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -1213,15 +1213,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -1233,20 +1233,20 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12,
                 IntProperty2 = 12
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 13,
                 IntProperty2 = 14
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -1254,11 +1254,11 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -1269,14 +1269,14 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 12,
                 IntEnumerableProperty = [11, 12]
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -1285,8 +1285,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -1295,15 +1295,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -1315,7 +1315,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -1325,22 +1325,22 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 13,
                 IntEnumerableProperty = [11, 12]
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntProperty = 14
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 
@@ -1351,14 +1351,14 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
             {
                 IntEnumerableProperty = [11, 12],
                 IntEnumerableProperty2 = [11, 13]
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
@@ -1367,8 +1367,8 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
@@ -1377,15 +1377,15 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel())
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
         });
     }
@@ -1397,7 +1397,7 @@ public class RuleCompilerTests
 
         var result = _sut.Compile<TestModel>(rule);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
         result.OnSome(cr =>
         {
             cr.DetailedApply(new TestModel
@@ -1407,22 +1407,22 @@ public class RuleCompilerTests
             })
             .Do(e =>
             {
-                e.IsLeft.Should().BeTrue();
-                e.UnwrapLeft().Should().Be("code");
+                e.IsLeft.ShouldBeTrue();
+                e.UnwrapLeft().ShouldBe("code");
             });
 
             cr.DetailedApply(new TestModel
             {
                 IntEnumerableProperty = [11, 12],
                 IntEnumerableProperty2 = [13, 14]
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
             cr.DetailedApply(new TestModel
             {
                 IntEnumerableProperty = [11, 12],
-            }).IsRight.Should().BeTrue();
+            }).IsRight.ShouldBeTrue();
 
-            cr.DetailedApply(new TestModel()).IsRight.Should().BeTrue();
+            cr.DetailedApply(new TestModel()).IsRight.ShouldBeTrue();
         });
     }
 }

--- a/tests/LogicEngine.Unit.Tests/Compilers/RulesCatalogCompilerTests.cs
+++ b/tests/LogicEngine.Unit.Tests/Compilers/RulesCatalogCompilerTests.cs
@@ -42,21 +42,21 @@ public class RulesCatalogCompilerTests
         var result = _sut.Compile<TestModel>(catalog);
 
         result
-            .Tee(r => r.IsSome.Should().BeTrue())
+            .Tee(r => r.IsSome.ShouldBeTrue())
             .OnSome(c =>
             {
                 var item = new AutoFaker<TestModel>().Generate();
 
-                c.Name.Should().Be("some name");
+                c.Name.ShouldBe("some name");
 
-                c.Apply(item).Should().BeFalse();
+                c.Apply(item).ShouldBeFalse();
 
                 c.DetailedApply(item)
-                    .Tee(e => e.IsLeft.Should().BeTrue())
-                    .OnLeft(s => s.Should().BeEquivalentTo("whatever"));
+                    .Tee(e => e.IsLeft.ShouldBeTrue())
+                    .OnLeft(s => s.ShouldBe(["whatever"]));
 
                 c.FirstMatching(item)
-                    .IsNone.Should().BeTrue();
+                    .IsNone.ShouldBeTrue();
             });
 
         _mockCompiler
@@ -86,20 +86,20 @@ public class RulesCatalogCompilerTests
         var result = _sut.Compile<TestModel>(catalog);
 
         result
-            .Tee(r => r.IsSome.Should().BeTrue())
+            .Tee(r => r.IsSome.ShouldBeTrue())
             .OnSome(c =>
             {
                 var item = new AutoFaker<TestModel>().Generate();
 
-                c.Name.Should().Be("some name");
+                c.Name.ShouldBe("some name");
 
-                c.Apply(item).Should().BeTrue();
+                c.Apply(item).ShouldBeTrue();
 
-                c.DetailedApply(item).IsRight.Should().BeTrue();
+                c.DetailedApply(item).IsRight.ShouldBeTrue();
 
                 c.FirstMatching(item)
-                    .Tee(o => o.IsSome.Should().BeTrue())
-                    .OnSome(s => s.Should().Be("set 1"));
+                    .Tee(o => o.IsSome.ShouldBeTrue())
+                    .OnSome(s => s.ShouldBe("set 1"));
             });
 
         _mockCompiler
@@ -142,24 +142,24 @@ public class RulesCatalogCompilerTests
         var result = _sut.Compile<TestModel>(catalog);
 
         result
-            .Tee(r => r.IsSome.Should().BeTrue())
+            .Tee(r => r.IsSome.ShouldBeTrue())
             .OnSome(c =>
             {
                 var item = new AutoFaker<TestModel>().Generate();
 
-                c.Name.Should().Be("some name");
+                c.Name.ShouldBe("some name");
 
-                c.Apply(item).Should().BeTrue();
+                c.Apply(item).ShouldBeTrue();
 
-                c.DetailedApply(item).IsRight.Should().BeTrue();
+                c.DetailedApply(item).IsRight.ShouldBeTrue();
 
                 c.FirstMatching(item)
-                    .Tee(o => o.IsSome.Should().BeTrue())
-                    .OnSome(s => s.Should().Be("set 1"));
+                    .Tee(o => o.IsSome.ShouldBeTrue())
+                    .OnSome(s => s.ShouldBe("set 1"));
             });
 
-        firstCalled.Should().BeTrue();
-        secondCalled.Should().BeFalse();
+        firstCalled.ShouldBeTrue();
+        secondCalled.ShouldBeFalse();
 
         _mockCompiler
             .Received(1)
@@ -215,25 +215,25 @@ public class RulesCatalogCompilerTests
         var result = _sut.Compile<TestModel>(catalog);
 
         result
-            .Tee(r => r.IsSome.Should().BeTrue())
+            .Tee(r => r.IsSome.ShouldBeTrue())
             .OnSome(c =>
             {
                 var item = new AutoFaker<TestModel>().Generate();
 
-                c.Name.Should().Be("some name");
+                c.Name.ShouldBe("some name");
 
-                c.Apply(item).Should().BeTrue();
+                c.Apply(item).ShouldBeTrue();
 
-                c.DetailedApply(item).IsRight.Should().BeTrue();
+                c.DetailedApply(item).IsRight.ShouldBeTrue();
 
                 c.FirstMatching(item)
-                    .Tee(o => o.IsSome.Should().BeTrue())
-                    .OnSome(s => s.Should().Be("set 1"));
+                    .Tee(o => o.IsSome.ShouldBeTrue())
+                    .OnSome(s => s.ShouldBe("set 1"));
             });
 
-        firstCalled.Should().BeTrue();
-        secondCalled.Should().BeFalse();
-        thirdCalled.Should().BeFalse();
+        firstCalled.ShouldBeTrue();
+        secondCalled.ShouldBeFalse();
+        thirdCalled.ShouldBeFalse();
 
         _mockCompiler
             .Received(1)
@@ -250,7 +250,7 @@ public class RulesCatalogCompilerTests
 
         var result = _sut.Compile<TestModel>(catalog);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 
     [Test]
@@ -260,6 +260,6 @@ public class RulesCatalogCompilerTests
 
         var result = _sut.Compile<TestModel>(catalog);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 }

--- a/tests/LogicEngine.Unit.Tests/Compilers/RulesSetCompilerTests.cs
+++ b/tests/LogicEngine.Unit.Tests/Compilers/RulesSetCompilerTests.cs
@@ -48,20 +48,20 @@ public class RulesSetCompilerTests
 
         var result = _sut.Compile<TestModel>(set);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
 
         result.OnSome(rs =>
         {
             var item = new AutoFaker<TestModel>().Generate();
 
-            rs.Apply(item).Should().BeFalse();
+            rs.Apply(item).ShouldBeFalse();
 
             rs.DetailedApply(item)
-                .Tee(a => a.IsLeft.Should().BeTrue())
-                .OnLeft(s => s.Should().BeEquivalentTo("whatever"));
+                .Tee(a => a.IsLeft.ShouldBeTrue())
+                .OnLeft(s => s.ShouldBe(["whatever"]));
 
             rs.FirstMatching(item)
-                .IsNone.Should().BeTrue();
+                .IsNone.ShouldBeTrue();
         });
     }
 
@@ -96,23 +96,23 @@ public class RulesSetCompilerTests
 
         var result = _sut.Compile<TestModel>(set);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
 
         result.OnSome(rs =>
         {
             var item = new AutoFaker<TestModel>().Generate();
 
-            rs.Apply(item).Should().BeTrue();
+            rs.Apply(item).ShouldBeTrue();
 
             rs.DetailedApply(item)
-                .Tee(a => a.IsRight.Should().BeTrue());
+                .Tee(a => a.IsRight.ShouldBeTrue());
 
             rs.FirstMatching(item)
-                .Tee(s => s.IsSome.Should().BeTrue())
-                .OnSome(s => s.Should().Be("code 1"));
+                .Tee(s => s.IsSome.ShouldBeTrue())
+                .OnSome(s => s.ShouldBe("code 1"));
 
-            firstExecuted.Should().BeTrue();
-            secondExecuted.Should().BeTrue();
+            firstExecuted.ShouldBeTrue();
+            secondExecuted.ShouldBeTrue();
         });
     }
 
@@ -150,24 +150,24 @@ public class RulesSetCompilerTests
 
         var result = _sut.Compile<TestModel>(set);
 
-        result.IsSome.Should().BeTrue();
+        result.IsSome.ShouldBeTrue();
 
         result.OnSome(rs =>
         {
             var item = new AutoFaker<TestModel>().Generate();
 
-            rs.Apply(item).Should().BeTrue();
+            rs.Apply(item).ShouldBeTrue();
 
             rs.DetailedApply(item)
-                .Tee(a => a.IsRight.Should().BeTrue());
+                .Tee(a => a.IsRight.ShouldBeTrue());
 
             rs.FirstMatching(item)
-                .Tee(s => s.IsSome.Should().BeTrue())
-                .OnSome(s => s.Should().Be("code 1"));
+                .Tee(s => s.IsSome.ShouldBeTrue())
+                .OnSome(s => s.ShouldBe("code 1"));
 
-            firstExecuted.Should().BeTrue();
-            secondExecuted.Should().BeTrue();
-            thirdExecuted.Should().BeFalse();
+            firstExecuted.ShouldBeTrue();
+            secondExecuted.ShouldBeTrue();
+            thirdExecuted.ShouldBeFalse();
         });
     }
 
@@ -192,7 +192,7 @@ public class RulesSetCompilerTests
 
         var result = _sut.Compile<TestModel>(set);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 
     [Test]
@@ -202,7 +202,7 @@ public class RulesSetCompilerTests
 
         var result = _sut.Compile<TestModel>(set);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 
     [Test]
@@ -212,6 +212,6 @@ public class RulesSetCompilerTests
 
         var result = _sut.Compile<TestModel>(set);
 
-        result.IsNone.Should().BeTrue();
+        result.IsNone.ShouldBeTrue();
     }
 }

--- a/tests/LogicEngine.Unit.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/tests/LogicEngine.Unit.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -81,8 +81,7 @@ public class EnumerableExtensionsTests
             .Returns(apply2);
 
         data.FirstOrDefault(mockAppliable)
-            .Should()
-            .BeEquivalentTo(expected);
+            .ShouldBe(expected);
     }
 
     [TestCaseSource(nameof(FilterTestCases))]
@@ -101,7 +100,6 @@ public class EnumerableExtensionsTests
             .Returns(apply2);
 
         data.Filter(mockAppliable)
-            .Should()
-            .BeEquivalentTo(expected);
+            .ShouldBe(expected);
     }
 }

--- a/tests/LogicEngine.Unit.Tests/Internals/StaticSharedTests.cs
+++ b/tests/LogicEngine.Unit.Tests/Internals/StaticSharedTests.cs
@@ -14,7 +14,7 @@ public class StaticSharedTests
         };
 
         StaticShared.Functions<TestModel>.Identity(input)
-            .Should().Be(input);
+            .ShouldBe(input);
     }
 
     [TestCase(1)]
@@ -28,7 +28,7 @@ public class StaticSharedTests
         };
 
         StaticShared.Functions<TestModel>.AlwaysTrue(input)
-            .Should().BeTrue();
+            .ShouldBeTrue();
     }
 
     [TestCase(1)]
@@ -46,7 +46,7 @@ public class StaticSharedTests
         };
 
         StaticShared.Functions<TestModel, object>.Constant(output)(input)
-            .Should().Be(output);
+            .ShouldBe(output);
     }
 
     [TestCase(1)]
@@ -60,6 +60,6 @@ public class StaticSharedTests
         };
 
         StaticShared.Functions<TestModel, object>.AlwaysRightEitherUnit(input)
-            .IsRight.Should().BeTrue();
+            .IsRight.ShouldBeTrue();
     }
 }

--- a/tests/LogicEngine.Unit.Tests/LogicEngine.Unit.Tests.csproj
+++ b/tests/LogicEngine.Unit.Tests/LogicEngine.Unit.Tests.csproj
@@ -9,7 +9,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
@@ -17,6 +16,7 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LogicEngine\LogicEngine.csproj" />

--- a/tests/LogicEngine.Unit.Tests/Models/RuleTests.cs
+++ b/tests/LogicEngine.Unit.Tests/Models/RuleTests.cs
@@ -42,8 +42,7 @@ public class RuleTests
         result
             .Replace("\n", "")
             .Replace("\r", "")
-            .Should()
-            .Be($"[Rule (property: property, operator: {expected}, value: value, code: code)]");
+            .ShouldBe($"[Rule (property: property, operator: {expected}, value: value, code: code)]");
     }
 
     [TestCase(null, "")]
@@ -54,6 +53,6 @@ public class RuleTests
     {
         var rule = new Rule("property", OperatorType.Equal, "value", code);
 
-        rule.Code.Should().Be(expected);
+        rule.Code.ShouldBe(expected);
     }
 }

--- a/tests/LogicEngine.Unit.Tests/RuleSetCompositionTests.cs
+++ b/tests/LogicEngine.Unit.Tests/RuleSetCompositionTests.cs
@@ -20,7 +20,7 @@ public class RuleSetCompositionTests
 
         var prodSet = set1 * set2;
 
-        prodSet.Rules.Should().BeEquivalentTo(new[] { rule1, rule2, rule3, rule4 });
-        prodSet.Name.Should().Be("(set 1 AND set 2)");
+        prodSet.Rules.ShouldBe([rule1, rule2, rule3, rule4]);
+        prodSet.Name.ShouldBe("(set 1 AND set 2)");
     }
 }

--- a/tests/LogicEngine.Unit.Tests/Usings.cs
+++ b/tests/LogicEngine.Unit.Tests/Usings.cs
@@ -1,3 +1,3 @@
-﻿global using FluentAssertions;
-global using NSubstitute;
+﻿global using NSubstitute;
 global using NUnit.Framework;
+global using Shouldly;


### PR DESCRIPTION
The changes in this diff involve replacing the usage of the `FluentAssertions` library with the `Shouldly` library in the unit tests. 

This includes updating assertions from the `FluentAssertions` syntax (e.g., `Should().BeTrue()`) to the `Shouldly` syntax (e.g., `ShouldBeTrue()`). 

These changes are motivated by the recent change in the license model of `FluentAssertions`, prompting a switch to an alternative assertion library (see [the new license](https://github.com/fluentassertions/fluentassertions/blob/develop/LICENSE.md) and the [XCeed website](https://xceed.com/products/unit-testing/))
